### PR TITLE
docs(spec): minor edits to improve readability

### DIFF
--- a/spec/1.overview.md
+++ b/spec/1.overview.md
@@ -24,13 +24,13 @@ Mantra relies on a set of core principles that will last for a long time. Then, 
 
 ## What Mantra is not?
 
-* It's not an application framework. An application framework takes cares of bundling, network transport, deployment, etc. Mantra uses Meteor as the application framework.
+* It's not an application framework. An application framework takes care of bundling, network transport, deployment, etc. Mantra uses Meteor as the application framework.
 * It's not a boilerplate, even though we have a directory structure. 
 * It's not a code generator. We may have a code generation tool, but that's not a core part of Mantra.
 
 ## Why a Spec?
 
-Mantra is an application architecture. There will be a lot of stakeholders for mantra including app developers, tool builders, tutorial authors and project managers, so it's very important to have a common standard everyone follows. That's what this specification does.
+Mantra is an application architecture. There will be a lot of stakeholders for Mantra including app developers, tool builders, tutorial authors and project managers, so it's very important to have a common standard everyone follows. That's what this specification does.
 
 ## Before You Read
 
@@ -41,4 +41,4 @@ This specification is written in a simple language. However, you may feel more c
 * React Containers
 * Meteor Basics (Pub/Sub, Tracker, ReactiveDict, etc.)
 
-Refer [Appendix A](#sec-Appendix-A-Prerequisite) to learn more about above areas.
+Refer [Appendix A](#sec-Appendix-A-Prerequisite) to learn more about the above areas.

--- a/spec/2.core-components.md
+++ b/spec/2.core-components.md
@@ -23,8 +23,8 @@ You could handle the React state inside a component, but that should not interac
 When writing your UI components, you can include any other React component. Here are a few places you can import React components:
 
 * Other UI components you define in your app
-* UI components from NPM (like meterial-ui)
-Any Containers in your app (we'll talk about this in a moment)
+* UI components from NPM (like material-ui)
+* Any Containers in your app (we'll talk about this in a moment)
 
 Any other thing to the component should be passed via props.
 
@@ -63,13 +63,13 @@ We have different solutions to manage states in our app, including:
 
 This is the place where a lot of innovation is happening in the JavaScript community. So, Mantra is flexible when it comes to state management. You can use anything you want.
 
-For example, you can use following for your app when starting:
+For example, you can use the following for your app when starting:
 
 * Meteor/MiniMongo (Remote State)
 * Tracker/ReactiveDict (Local State)
 * FlowRouter (Local State)
 
-Later on you can move into different solutions.
+Later on you can move on to different solutions.
 
 Note: However, Mantra enforces a few rules when managing your states.
 
@@ -85,7 +85,7 @@ See the following links for some sample usage of states:
 
 ## Containers
 
-Containers are the integration layer in Mantra. They do:
+Containers are the integration layer in Mantra. They do the following:
 
 * pass states into UI components
 * pass actions into UI components
@@ -112,7 +112,7 @@ Note: If you need to pass the application context to a component, do it via prop
 
 ## Application Context
 
-Application Context is available to all the actions and containers, so this is place for shared variables in your app. These include:
+Application Context is available to all the actions and containers, so this is the place for shared variables in your app. These include:
 
 * Meteor namespace
 * Meteor Collections
@@ -131,7 +131,7 @@ Mantra uses dependency injection to isolate different parts of your app includin
 
 We use a project called [`react-simple-di`](https://github.com/kadirahq/react-simple-di) that uses React Context behind the scene. It accepts both application context and actions as dependencies. 
 
-Once configured, application context will be injected into each action. That's the first argument of an action. So, you don't need pass the application context manually.
+Once configured, application context will be injected into each action. That's the first argument of an action. So, you don't need to pass the application context manually.
 
 ### Configuring Dependency Injections
 
@@ -143,7 +143,7 @@ Dependencies will be injected to the top-level components in your app. This coul
 
 Note: Here, when referring to components, we will consider both containers and UI components.
 
-We normally use a Router to mount components into the UI. There could be multiple solutions (for example, FlowRouter and ReactRouter).
+We normally use a Router to mount components into the UI. There could be multiple solutions (for example, FlowRouter and React Router).
 
 The Router's only functionality in Mantra is to mount components to the UI. It's just a tool.
 
@@ -151,7 +151,7 @@ Click [here](https://github.com/mantrajs/mantra-sample-blog-app/blob/master/clie
 
 ## Single Entry Point
 
-In Mantra, we want the app to be predictable. Thereore, there is only a single entry point in your app. Usually, it will load routes.
+In Mantra, we want the app to be predictable. Therefore, there is only a single entry point in your app. Usually, it will load routes.
 
 [Click here for an example entry point.](https://github.com/mantrajs/mantra-sample-blog-app/blob/master/client/main.js)
 

--- a/spec/4.future-work.md
+++ b/spec/4.future-work.md
@@ -1,15 +1,15 @@
 # Future Work
 
-Mantra is a draft and there may be a lot of missing pieces and improvements we can do. We've currently identified following features are important to Mantra and will be available in near future.
+Mantra is a draft and there may be a lot of missing pieces and improvements we can do. We've currently identified the following features as important to Mantra and will be available in near future.
 
 ## Mantra Modules
 
-Mantra modules help you to put actions, UI components and containers related to common functionality into a single place. You can publish them to NPM and share with others.
+Mantra modules will help you put actions, UI components and containers related to a common functionality into a single place. You can publish them to NPM and share with others.
 
-Note: We don't have a proper way to do this now. Try to do experiments and [share](https://github.com/kadirahq/mantra/issues/3) your experience with us.
+Note: We don't have a proper way to do this now. Try experimenting and [share](https://github.com/kadirahq/mantra/issues/3) your experience with us.
 
 ## Server Side Rendering (SSR)
 
-It's extremely possible to do SSR with Mantra. We are trying to this with tool agnostic manner, but the reference implementation will be based on FlowRouter SSR.
+It's extremely possible to do SSR with Mantra. We are trying to do this in a tool agnostic manner, but the reference implementation will be based on FlowRouter SSR.
 
 


### PR DESCRIPTION
Really love the work you are doing with Mantra. I've made a handful of suggestions for minor edits to improve readability. My goal was to follow American English idioms and improve overall consistency (e.g. capitalizing Mantra). I know these are pretty nitpicky but hopefully it's helpful and makes the guide even easier to read for others.
