### PR TITLE
docs(overview): improve readability

### DIFF
--- a/spec/1.overview.md
+++ b/spec/1.overview.md
@@ -30,7 +30,7 @@ Mantra relies on a set of core principles that will last for a long time. Then, 
 
 ## What Mantra is?
 
-* It's a set of standards on how to architecture a Meteor app.
+* It's a set of standards on how to architect a Meteor app.
 * It also comes with a set of curated libraries which helps you to implement Mantra on top of Meteor.
 
 ## Why a Spec?


### PR DESCRIPTION
Alternatively it could be "how to develop an architecture for a Meteor app", but I think "but how to architect" is more succinct and idiomatic.
