### PR TITLE
Fix an example

### DIFF
--- a/spec/3.dir-layout.md
+++ b/spec/3.dir-layout.md
@@ -188,7 +188,7 @@ Here's a typical module definition:
 ```js
 import methodStubs from './configs/method_stubs';
 import actions from './actions';
-import routes from './configs/routes.jsx';
+import routes from './routes.jsx';
 
 export default {
   routes,


### PR DESCRIPTION
The path to `routes.jsx` file does not follow the directory layout in the section [3.1.2](https://kadirahq.github.io/mantra/#sec-modules), and the [code from example repo](https://github.com/mantrajs/mantra-sample-blog-app/blob/master/client/modules/core/index.js#L3)
